### PR TITLE
ci: build docker image and push to container registry

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,43 @@
+name: Build Docker and Optional Push
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - demo
+      - hotfix
+  pull_request:
+    branches:
+      - main
+      - dev
+      - demo
+      - hotfix
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  docker-build:
+    strategy:
+      matrix:
+        include:
+          - app_name: cmsabackend
+            dockerfile: docker/Backend.Dockerfile
+            password_secret: DOCKER_PASSWORD
+          - app_name: cmsafrontend
+            dockerfile: docker/Frontend.Dockerfile
+            password_secret: DOCKER_PASSWORD
+    uses: ./.github/workflows/build-docker.yml
+    with:
+      registry: codegencontainerregpk.azurecr.io
+      username: codegencontainerregpk
+      password_secret: ${{ matrix.password_secret }}
+      app_name: ${{ matrix.app_name }}
+      dockerfile: ${{ matrix.dockerfile }}
+      push: ${{ github.event_name == 'push' || github.base_ref == 'main' || github.base_ref == 'dev' || github.base_ref == 'demo' || github.base_ref == 'hotfix' }}
+    secrets: inherit

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -39,5 +39,5 @@ jobs:
       password_secret: ${{ matrix.password_secret }}
       app_name: ${{ matrix.app_name }}
       dockerfile: ${{ matrix.dockerfile }}
-      push: ${{ github.event_name == 'push' || github.base_ref == 'main' || github.base_ref == 'dev' || github.base_ref == 'demo' || github.base_ref == 'hotfix' }}
+      push: ${{ github.base_ref == 'main' || github.base_ref == 'dev' || github.base_ref == 'demo' || github.base_ref == 'hotfix' }}
     secrets: inherit

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -39,5 +39,5 @@ jobs:
       password_secret: ${{ matrix.password_secret }}
       app_name: ${{ matrix.app_name }}
       dockerfile: ${{ matrix.dockerfile }}
-      push: ${{ github.base_ref == 'main' || github.base_ref == 'dev' || github.base_ref == 'demo' || github.base_ref == 'hotfix' }}
+      push: ${{ github.ref_name == 'main' || github.ref_name == 'dev' || github.ref_name == 'demo' || github.ref_name == 'hotfix' }}
     secrets: inherit

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -39,4 +39,5 @@ jobs:
       password_secret: ${{ matrix.password_secret }}
       app_name: ${{ matrix.app_name }}
       dockerfile: ${{ matrix.dockerfile }}
+      push: ${{ github.base_ref == 'main' || github.base_ref == 'dev' || github.base_ref == 'demo' || github.base_ref == 'hotfix' }}
     secrets: inherit

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -39,5 +39,4 @@ jobs:
       password_secret: ${{ matrix.password_secret }}
       app_name: ${{ matrix.app_name }}
       dockerfile: ${{ matrix.dockerfile }}
-      push: ${{ github.base_ref == 'main' || github.base_ref == 'dev' || github.base_ref == 'demo' || github.base_ref == 'hotfix' }}
     secrets: inherit

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,78 @@
+name: Reusable Docker build and push workflow
+
+on:
+  workflow_call:
+    inputs:
+      registry:
+        required: true
+        type: string
+      username:
+        required: true
+        type: string
+      password_secret:
+        required: true
+        type: string
+      app_name:
+        required: true
+        type: string
+      dockerfile:
+        required: true
+        type: string
+      push:
+        required: true
+        type: boolean
+    secrets:
+      DOCKER_PASSWORD:
+        required: true
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Docker Login
+      if: ${{ inputs.push }}
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ secrets[inputs.password_secret] }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+    - name: Determine Tag Name Based on Branch
+      id: determine_tag
+      run: |
+        if [[ "${{ github.base_ref }}" == "main" ]]; then
+          echo "tagname=latest" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "dev" ]]; then
+          echo "tagname=dev" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "demo" ]]; then
+          echo "tagname=demo" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "hotfix" ]]; then
+          echo "tagname=hotfix" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.base_ref }}" == "dependabotchanges" ]]; then
+          echo "tagname=dependabotchanges" >> $GITHUB_OUTPUT
+        else
+          echo "tagname=default" >> $GITHUB_OUTPUT
+        fi
+
+
+    - name: Build Docker Image and optionally push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        push: ${{ inputs.push }}
+        cache-from: type=registry,ref=${{ inputs.registry }}/${{ inputs.app_name}}:${{ steps.determine_tag.outputs.tagname }}
+        tags: |
+          ${{ inputs.registry }}/${{ inputs.app_name}}:${{ steps.determine_tag.outputs.tagname }}
+          ${{ inputs.registry }}/${{ inputs.app_name}}:${{ steps.determine_tag.outputs.tagname }}_${{ steps.date.outputs.date }}_${{ github.run_number }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -54,15 +54,15 @@ jobs:
     - name: Determine Tag Name Based on Branch
       id: determine_tag
       run: |
-        if [[ "${{ github.base_ref }}" == "main" ]]; then
+        if [[ "${{ github.ref_name }}" == "main" ]]; then
           echo "tagname=latest" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.base_ref }}" == "dev" ]]; then
+        elif [[ "${{ github.ref_name }}" == "dev" ]]; then
           echo "tagname=dev" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.base_ref }}" == "demo" ]]; then
+        elif [[ "${{ github.ref_name }}" == "demo" ]]; then
           echo "tagname=demo" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.base_ref }}" == "hotfix" ]]; then
+        elif [[ "${{ github.ref_name }}" == "hotfix" ]]; then
           echo "tagname=hotfix" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.base_ref }}" == "dependabotchanges" ]]; then
+        elif [[ "${{ github.ref_name }}" == "dependabotchanges" ]]; then
           echo "tagname=dependabotchanges" >> $GITHUB_OUTPUT
         else
           echo "tagname=default" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -32,6 +32,9 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
+    
+    - name: push debug
+      run: echo ${{ inputs.push }}
 
     - name: Docker Login
       if: ${{ inputs.push }}


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows to build and optionally push Docker images for different branches and pull request events. The main changes include the creation of a reusable Docker build and push workflow, and the implementation of a workflow that utilizes this reusable workflow for specific branches and events.

Workflow additions:

* [`.github/workflows/build-docker-images.yml`](diffhunk://#diff-2817fc9ec6443e19233164eefa86576a0972ce81bcf0ec4a04f96d6119db038eR1-R43): Created a new workflow to build and optionally push Docker images for the `main`, `dev`, `demo`, and `hotfix` branches, as well as for pull requests targeting these branches. The workflow uses a matrix strategy to handle both backend and frontend applications.

Reusable workflow:

* [`.github/workflows/build-docker.yml`](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fR1-R78): Introduced a reusable workflow for building and pushing Docker images. This workflow includes steps for checking out the repository, logging into Docker, setting up Docker Buildx, determining the tag name based on the branch, and building and optionally pushing the Docker image.